### PR TITLE
Fix numpy object non json serializable error

### DIFF
--- a/bigdatavoyant/report.py
+++ b/bigdatavoyant/report.py
@@ -26,7 +26,7 @@ class Report(dict):
 
     def __str__(self):
         """Overrides the parent method."""
-        return json.dumps(self, indent=2)
+        return json.dumps(self, indent=2, default=convert)
 
     def to_json(self, indent=None):
         """Converts to JSON.

--- a/bigdatavoyant/report.py
+++ b/bigdatavoyant/report.py
@@ -1,4 +1,5 @@
 import json
+import numpy
 from dicttoxml import dicttoxml
 from xml.dom.minidom import parseString
 import yaml

--- a/bigdatavoyant/report.py
+++ b/bigdatavoyant/report.py
@@ -4,6 +4,15 @@ from xml.dom.minidom import parseString
 import yaml
 import os
 
+
+def convert(o):
+    if isinstance(o, numpy.int64) or isinstance(o, numpy.int32):
+        return int(o)
+    elif isinstance(o, numpy.float64) or isinstance(o, numpy.float32):
+        return float(o)
+    raise TypeError
+
+
 class Report(dict):
     """A collection of useful methods for reporting."""
 
@@ -25,7 +34,7 @@ class Report(dict):
         Returns:
             (string) json representation of the report.
         """
-        return json.dumps(self, indent=indent)
+        return json.dumps(self, indent=indent, default=convert)
 
     def to_xml(self):
         """Converts to xml.


### PR DESCRIPTION
Changes proposed in this pull request:
- Check whether the JSON response contains NumPy int(32, 64) or float(32, 64) objects and convert them to pure Python ints and floats.