### PR TITLE
decode byte arrays for the json report

### DIFF
--- a/bigdatavoyant/report.py
+++ b/bigdatavoyant/report.py
@@ -11,6 +11,8 @@ def convert(o):
         return int(o)
     elif isinstance(o, numpy.float64) or isinstance(o, numpy.float32):
         return float(o)
+    elif isinstance(o, bytes):
+        return o.decode('utf-8')
     raise TypeError
 
 


### PR DESCRIPTION
Fixes the case where there are byte arrays in the report and cannot be serialized to JSON by default
